### PR TITLE
Fix and refactor ast

### DIFF
--- a/Go/bin/astExample.ml
+++ b/Go/bin/astExample.ml
@@ -6,38 +6,41 @@ open Ast
 
 let () =
   let factorial_ast : func_decl =
-    { func_name = "factorial" (* function identificator *)
-    ; args = Some [ "n", Some Type_int ] (* arguments *)
-    ; return_types =
-        (* return types *)
-        Some [ (* variable name *) None, (* type *) Some Type_int ]
-    ; body =
-        (* function body *)
-        Stmt_block
-          [ Stmt_if
-              (* if statement *)
-              ( None (* initialization *)
-              , (* condition *)
-                Expr_bin_oper (Bin_equal, Expr_ident "n", Expr_const (Const_int 0))
-              , (* "if" branch *)
-                Stmt_return (Some (Expr_const (Const_int 1)))
-              , (* "else" branch *)
-                Some
-                  (Stmt_return
-                     (Some
-                        (Expr_bin_oper
-                           ( Bin_multiply
-                           , Expr_ident "n"
-                           , Expr_call
-                               ( Expr_ident "factorial"
-                               , Some
-                                   [ Expr_bin_oper
-                                       ( Bin_subtract
-                                       , Expr_ident "n"
-                                       , Expr_const (Const_int 1) )
-                                   ] ) )))) )
-          ]
-    }
+    ( "factorial"
+    , (* function identificator *)
+      { args = Some [ "n", Some Type_int ] (* arguments *)
+      ; return_types =
+          (* return types *)
+          Some [ (* variable name *) None, (* type *) Some Type_int ]
+      ; body =
+          (* function body *)
+          Some
+            (Stmt_block
+               [ Stmt_if
+                   (* if statement *)
+                   ( (* initialization *)
+                     None
+                   , (* condition *)
+                     Expr_bin_oper (Bin_equal, Expr_ident "n", Expr_const (Const_int 0))
+                   , (* "if" branch *)
+                     Some (Stmt_return (Some (Expr_const (Const_int 1))))
+                   , (* "else" branch *)
+                     Some
+                       (Stmt_return
+                          (Some
+                             (Expr_bin_oper
+                                ( Bin_multiply
+                                , Expr_ident "n"
+                                , Expr_call
+                                    ( Expr_ident "factorial"
+                                    , Some
+                                        [ Expr_bin_oper
+                                            ( Bin_subtract
+                                            , Expr_ident "n"
+                                            , Expr_const (Const_int 1) )
+                                        ] ) )))) )
+               ])
+      } )
   in
   print_endline (show_func_decl factorial_ast)
 ;;

--- a/Go/bin/astExample.ml
+++ b/Go/bin/astExample.ml
@@ -6,36 +6,39 @@ open Ast
 
 let () =
   let factorial_ast : func_decl =
-    ( "factorial" (* function identificator *)
-    , Some [ "n", Some Type_int ] (* arguments *)
-    , Some [ Type_int ] (* return type *)
-    , Stmt_block
-        (* body *)
-        [ Stmt_if
-            (* if statement *)
-            ( None (* initialization *)
-            , (* condition *)
-              Expr_bin_oper (Bin_equal, Expr_ident "n", Expr_const (Const_int 1))
-            , (* if body *)
-              Stmt_return (Some (Expr_const (Const_int 1)))
-            , (* else body *)
-              Some
-                (Stmt_return
-                   (Some
-                      (Expr_bin_oper
-                         ( Bin_multiply
-                         , Expr_ident "n"
-                         , Expr_call
-                             ( None
-                             , Expr_ident "factorial" (* function identificator *)
-                             , (* function arguments *)
-                               Some
-                                 [ Expr_bin_oper
-                                     ( Bin_subtract
-                                     , Expr_ident "n"
-                                     , Expr_const (Const_int 1) )
-                                 ] ) )))) )
-        ] )
+    { func_name = "factorial" (* function identificator *)
+    ; args = Some [ "n", Some Type_int ] (* arguments *)
+    ; return_types =
+        (* return types *)
+        Some [ (* variable name *) None, (* type *) Some Type_int ]
+    ; body =
+        (* function body *)
+        Stmt_block
+          [ Stmt_if
+              (* if statement *)
+              ( None (* initialization *)
+              , (* condition *)
+                Expr_bin_oper (Bin_equal, Expr_ident "n", Expr_const (Const_int 0))
+              , (* "if" branch *)
+                Stmt_return (Some (Expr_const (Const_int 1)))
+              , (* "else" branch *)
+                Some
+                  (Stmt_return
+                     (Some
+                        (Expr_bin_oper
+                           ( Bin_multiply
+                           , Expr_ident "n"
+                           , Expr_call
+                               ( None
+                               , Expr_ident "factorial"
+                               , Some
+                                   [ Expr_bin_oper
+                                       ( Bin_subtract
+                                       , Expr_ident "n"
+                                       , Expr_const (Const_int 1) )
+                                   ] ) )))) )
+          ]
+    }
   in
   print_endline (show_func_decl factorial_ast)
 ;;

--- a/Go/bin/astExample.ml
+++ b/Go/bin/astExample.ml
@@ -26,7 +26,8 @@ let () =
                          ( Bin_multiply
                          , Expr_ident "n"
                          , Expr_call
-                             ( Expr_ident "factorial" (* function identificator *)
+                             ( None
+                             , Expr_ident "factorial" (* function identificator *)
                              , (* function arguments *)
                                Some
                                  [ Expr_bin_oper

--- a/Go/bin/astExample.ml
+++ b/Go/bin/astExample.ml
@@ -29,8 +29,7 @@ let () =
                            ( Bin_multiply
                            , Expr_ident "n"
                            , Expr_call
-                               ( None
-                               , Expr_ident "factorial"
+                               ( Expr_ident "factorial"
                                , Some
                                    [ Expr_bin_oper
                                        ( Bin_subtract

--- a/Go/bin/astExample.ml
+++ b/Go/bin/astExample.ml
@@ -15,7 +15,7 @@ let () =
             (* if statement *)
             ( None (* initialization *)
             , (* condition *)
-              Expr_bin_oper (Bin_equal (Expr_ident "n", Expr_const (Const_int 1)))
+              Expr_bin_oper (Bin_equal, Expr_ident "n", Expr_const (Const_int 1))
             , (* if body *)
               Stmt_return (Some (Expr_const (Const_int 1)))
             , (* else body *)
@@ -23,17 +23,17 @@ let () =
                 (Stmt_return
                    (Some
                       (Expr_bin_oper
-                         (Bin_multiply
-                            ( Expr_ident "n"
-                            , Expr_call
-                                (* function call *)
-                                ( Expr_ident "factorial" (* function identificator *)
-                                , (* function arguments *)
-                                  Some
-                                    [ Expr_bin_oper
-                                        (Bin_subtract
-                                           (Expr_ident "n", Expr_const (Const_int 1)))
-                                    ] ) ))))) )
+                         ( Bin_multiply
+                         , Expr_ident "n"
+                         , Expr_call
+                             ( Expr_ident "factorial" (* function identificator *)
+                             , (* function arguments *)
+                               Some
+                                 [ Expr_bin_oper
+                                     ( Bin_subtract
+                                     , Expr_ident "n"
+                                     , Expr_const (Const_int 1) )
+                                 ] ) )))) )
         ] )
   in
   print_endline (show_func_decl factorial_ast)

--- a/Go/lib/ast/ast.ml
+++ b/Go/lib/ast/ast.ml
@@ -53,6 +53,7 @@ and unary_oper =
 type expr =
   | Expr_nil (** A value of an unitialized channel or function: [nil] *)
   | Expr_const of const (** Constants such as [5], ["hi"], [false] *)
+  | Expr_array of type' * expr list option (** Arrays such as [[3]int{3, get_four()}] *)
   | Expr_ident of ident (** An identificator for a variable such as [x] *)
   | Expr_index of expr * expr
   (** An access to an array element by its index such as: [my_array[i]], [get_array(1)[0]]*)

--- a/Go/lib/ast/ast.ml
+++ b/Go/lib/ast/ast.ml
@@ -32,8 +32,9 @@ type expr =
   | Expr_ident of ident (** An identificator for a variable such as [x] *)
   | Expr_index of ident * expr
   (** An access to an array element by its index: [my_array[i]]*)
-  | Expr_bin_oper of bin_oper (** Binary operations such as [a + b], [x || y] *)
-  | Expr_un_oper of unary_oper (** Unary operations such as [!z], [-f] *)
+  | Expr_bin_oper of bin_oper * expr * expr
+  (** Binary operations such as [a + b], [x || y] *)
+  | Expr_un_oper of unary_oper * expr (** Unary operations such as [!z], [-f] *)
   | Expr_anon_func of (ident * type' option) list option * type' list option * stmt
   (** An anonymous function such as [func() {}], [func(a int, b int) int { return a + b }] *)
   | Expr_call of expr * expr list option
@@ -43,28 +44,30 @@ type expr =
       [func() { println("hello") }()] *)
 [@@deriving show { with_path = false }]
 
+and expr_call = expr * expr list option
+
 (** Binary operations *)
 and bin_oper =
-  | Bin_sum of expr * expr (** Binary sum: [1 + 1] *)
-  | Bin_multiply of expr * expr (** Binary multiplication: [a * 5] *)
-  | Bin_subtract of expr * expr (** Binary subtraction: [func1(x) - func2(y)] *)
-  | Bin_divide of expr * expr (** Binary divison: [7 / 3] *)
-  | Bin_modulus of expr * expr (** Binary division by modulus: [123 % 10] *)
-  | Bin_equal of expr * expr (** Binary check for equality: [result == 25] *)
-  | Bin_not_equal of expr * expr (** Binary check for inequlity: [i != n] *)
-  | Bin_greater of expr * expr (** Binary "greater than": [sum > minimum] *)
-  | Bin_greater_equal of expr * expr (** Binary "greater than or equal": [b >= a] *)
-  | Bin_less of expr * expr (** Binary "less than": [sum < maximum] *)
-  | Bin_less_equal of expr * expr (** Binary "less than or equal": [a <= b] *)
-  | Bin_and of expr * expr (** Binary "and": [ok && flag] *)
-  | Bin_or of expr * expr (** Binary "or": [is_online || is_friend] *)
+  | Bin_sum (** Binary sum: [1 + 1] *)
+  | Bin_multiply (** Binary multiplication: [a * 5] *)
+  | Bin_subtract (** Binary subtraction: [func1(x) - func2(y)] *)
+  | Bin_divide (** Binary divison: [7 / 3] *)
+  | Bin_modulus (** Binary division by modulus: [123 % 10] *)
+  | Bin_equal (** Binary check for equality: [result == 25] *)
+  | Bin_not_equal (** Binary check for inequlity: [i != n] *)
+  | Bin_greater (** Binary "greater than": [sum > minimum] *)
+  | Bin_greater_equal (** Binary "greater than or equal": [b >= a] *)
+  | Bin_less (** Binary "less than": [sum < maximum] *)
+  | Bin_less_equal (** Binary "less than or equal": [a <= b] *)
+  | Bin_and (** Binary "and": [ok && flag] *)
+  | Bin_or (** Binary "or": [is_online || is_friend] *)
 [@@deriving show { with_path = false }]
 
 (** Unary operations *)
 and unary_oper =
-  | Unary_not of expr (** Unary negation: [!x] *)
-  | Unary_plus of expr (** Unary plus: [+a] *)
-  | Unary_minus of expr (** Unary minus: [-a]*)
+  | Unary_not (** Unary negation: [!x] *)
+  | Unary_plus (** Unary plus: [+a] *)
+  | Unary_minus (** Unary minus: [-a]*)
 [@@deriving show { with_path = false }]
 
 (** Statement, a syntactic unit of imperative programming *)

--- a/Go/lib/ast/ast.ml
+++ b/Go/lib/ast/ast.ml
@@ -7,7 +7,7 @@ type type' =
   | Type_int (** Integer type: [int] *)
   | Type_string (** String type: [string] *)
   | Type_bool (** Boolean type: [bool] *)
-  | Type_array of type' * size (** Array types such as [int[6]], [string[0]] *)
+  | Type_array of type' * size (** Array types such as [[6]int], [[0]string] *)
   | Type_func of type' list option * type' list option
   (** Function types such as [func()], [func(string) (bool, int)] *)
   | Type_chan of type' (** Channel type [chan int] *)

--- a/Go/lib/ast/ast.ml
+++ b/Go/lib/ast/ast.ml
@@ -43,7 +43,7 @@ type bin_oper =
 [@@deriving show { with_path = false }]
 
 (** Unary operators *)
-and unary_oper =
+type unary_oper =
   | Unary_not (** Unary negation: [!] *)
   | Unary_plus (** Unary plus: [+] *)
   | Unary_minus (** Unary minus: [-]*)
@@ -60,16 +60,27 @@ type expr =
   | Expr_bin_oper of bin_oper * expr * expr
   (** Binary operations such as [a + b], [x || y] *)
   | Expr_un_oper of unary_oper * expr (** Unary operations such as [!z], [-f] *)
-  | Expr_anon_func of (ident * type' option) list option * type' list option * stmt option
-  (** An anonymous function such as [func() {}], [func(a int, b int) int { return a + b }] *)
+  | Expr_anon_func of anon_func (** See anon_func type *)
   | Expr_call of func_call (** See func_call type *)
+[@@deriving show { with_path = false }]
+
+(** An anonymous functions such as:
+    [func() {}],
+    [func(a, b int) (sum int) { sum = a + b; return }]
+    [func(s1 string, s2 string) [2]string { return [2]string{s1,s2} }] *)
+and anon_func =
+  { args : (ident * type' option) list option (** arguments *)
+  ; return_types : (ident option * type' option) list option
+  (** return types, optional var names *)
+  ; body : stmt option (** function body *)
+  }
 [@@deriving show { with_path = false }]
 
 (** function calls such as:
     [my_func(arg1, arg2)],
     [c()()()],
     [func() { println("hello") }()] *)
-and func_call = expr * expr list option
+and func_call = expr * expr list option [@@deriving show { with_path = false }]
 
 (** Statement, a syntactic unit of imperative programming *)
 and stmt =
@@ -126,14 +137,7 @@ and var_decl =
       diff = a - b
       return
     }] *)
-type func_decl =
-  { func_name : ident (** function name *)
-  ; args : (ident * type' option) list option (** arguments *)
-  ; return_types : (ident option * type' option) list option
-  (** return types, optional var names *)
-  ; body : stmt option (** function body *)
-  }
-[@@deriving show { with_path = false }]
+type func_decl = ident * anon_func [@@deriving show { with_path = false }]
 
 (** Top-level declarations *)
 type top_decl =

--- a/Go/lib/ast/ast.ml
+++ b/Go/lib/ast/ast.ml
@@ -37,14 +37,17 @@ type expr =
   | Expr_un_oper of unary_oper * expr (** Unary operations such as [!z], [-f] *)
   | Expr_anon_func of (ident * type' option) list option * type' list option * stmt
   (** An anonymous function such as [func() {}], [func(a int, b int) int { return a + b }] *)
-  | Expr_call of expr * expr list option
+  | Expr_call of func_modifier option * expr * expr list option
   (** function calls such as:
       [my_func(arg1, arg2)],
       [c()()()],
       [func() { println("hello") }()] *)
 [@@deriving show { with_path = false }]
 
-and expr_call = expr * expr list option
+(** Expr_call modifiers *)
+and func_modifier =
+  | Mod_defer (** Defer modifier: [defer func()] *)
+  | Mod_go (** Goroutine modifier: [go func(ch chan<- bool)] *)
 
 (** Binary operations *)
 and bin_oper =
@@ -103,12 +106,11 @@ and stmt =
   | Stmt_continue (** Continue statement: [continue] *)
   | Stmt_return of expr option
   (** Return statement such as [return some_expr] or [return] *)
-  | Stmt_defer of expr (** Defer statement such as [defer close_file()] *)
   | Stmt_block of stmt list (** Block of statements in curly braces *)
-  | Stmt_call of expr * expr list option (** The same as Expr_call in expr type *)
+  | Stmt_call of func_modifier option * expr * expr list option
+  (** The same as Expr_call in expr type *)
   | Stmt_channel_send of ident * expr (** Channel send operation [c <- true] *)
   | Stmt_channel_recieve of ident * expr (** Channel recieve operation [z := <-c] *)
-  | Stmt_go of expr (** Goroutine statement: [go func(ch chan<- bool)] *)
 [@@deriving show { with_path = false }]
 
 (** Top-level declarations *)

--- a/Go/lib/ast/ast.ml
+++ b/Go/lib/ast/ast.ml
@@ -60,7 +60,7 @@ type expr =
   | Expr_bin_oper of bin_oper * expr * expr
   (** Binary operations such as [a + b], [x || y] *)
   | Expr_un_oper of unary_oper * expr (** Unary operations such as [!z], [-f] *)
-  | Expr_anon_func of (ident * type' option) list option * type' list option * stmt
+  | Expr_anon_func of (ident * type' option) list option * type' list option * stmt option
   (** An anonymous function such as [func() {}], [func(a int, b int) int { return a + b }] *)
   | Expr_call of func_call (** See func_call type *)
 [@@deriving show { with_path = false }]
@@ -73,37 +73,36 @@ and func_call = expr * expr list option
 
 (** Statement, a syntactic unit of imperative programming *)
 and stmt =
-  | Stmt_empty (** Empty statement, i. e. empty function body *)
   | Stmt_var_decl of var_decl (** See var_decl type *)
   | Stmt_assign of ident list * expr list
   (** Assignment to a variable such as [a = 3], [a, b = 4, 5] *)
   | Stmt_incr of ident (** An increment of a variable: [a++] *)
   | Stmt_decr of ident (** A decrement of a variable: [a--] *)
-  | Stmt_if of stmt option * expr * stmt * stmt option
+  | Stmt_if of stmt option * expr * stmt option * stmt option
   (** An if statement such as:
       [if a := 5; a >= 4 {
           do()
       } else {
           do_else()
       }] *)
-  | Stmt_for of stmt option * expr option * stmt option * stmt
+  | Stmt_for of stmt option * expr option * stmt option * stmt option
   (** A for statement such as:
       [for i := 0; i < n; i++ {
           do()
       }] *)
-  | Stmt_range of ident * ident option * ident * stmt
+  | Stmt_range of ident * ident option * ident * stmt option
   (** For with range statement such as:
       [for i, elem := range array {
           check(elem)
       }] *)
-  | Stmt_break (** Break statemnet: [break] *)
+  | Stmt_break (** Break statement: [break] *)
   | Stmt_continue (** Continue statement: [continue] *)
   | Stmt_return of expr option
   (** Return statement such as [return some_expr] or [return] *)
   | Stmt_block of stmt list (** Block of statements in curly braces *)
-  | Stmt_call of func_call (** See func_call type *)
   | Stmt_chan_send of ident * expr (** Channel send operation [c <- true] *)
   | Stmt_chan_recieve of ident * expr (** Channel recieve operation [z := <-c] *)
+  | Stmt_call of func_call (** See func_call type *)
   | Stmt_defer of func_call (** See func_call type *)
   | Stmt_go of func_call (** See func_call type *)
 [@@deriving show { with_path = false }]
@@ -132,7 +131,7 @@ type func_decl =
   ; args : (ident * type' option) list option (** arguments *)
   ; return_types : (ident option * type' option) list option
   (** return types, optional var names *)
-  ; body : stmt (** function body *)
+  ; body : stmt option (** function body *)
   }
 [@@deriving show { with_path = false }]
 

--- a/Go/tests/test_ast.t
+++ b/Go/tests/test_ast.t
@@ -5,18 +5,17 @@ SPDX-License-Identifier: MIT
   ("factorial", (Some [("n", (Some Type_int))]), (Some [Type_int]),
    (Stmt_block
       [(Stmt_if (None,
-          (Expr_bin_oper
-             (Bin_equal ((Expr_ident "n"), (Expr_const (Const_int 1))))),
+          (Expr_bin_oper (Bin_equal, (Expr_ident "n"),
+             (Expr_const (Const_int 1)))),
           (Stmt_return (Some (Expr_const (Const_int 1)))),
           (Some (Stmt_return
-                   (Some (Expr_bin_oper
-                            (Bin_multiply ((Expr_ident "n"),
-                               (Expr_call ((Expr_ident "factorial"),
-                                  (Some [(Expr_bin_oper
-                                            (Bin_subtract ((Expr_ident "n"),
-                                               (Expr_const (Const_int 1)))))
-                                          ])
-                                  ))
-                               ))))))
+                   (Some (Expr_bin_oper (Bin_multiply, (Expr_ident "n"),
+                            (Expr_call ((Expr_ident "factorial"),
+                               (Some [(Expr_bin_oper (Bin_subtract,
+                                         (Expr_ident "n"),
+                                         (Expr_const (Const_int 1))))
+                                       ])
+                               ))
+                            )))))
           ))
         ]))

--- a/Go/tests/test_ast.t
+++ b/Go/tests/test_ast.t
@@ -12,12 +12,12 @@ SPDX-License-Identifier: MIT
            (Stmt_return (Some (Expr_const (Const_int 1)))),
            (Some (Stmt_return
                     (Some (Expr_bin_oper (Bin_multiply, (Expr_ident "n"),
-                             (Expr_call (None, (Expr_ident "factorial"),
-                                (Some [(Expr_bin_oper (Bin_subtract,
-                                          (Expr_ident "n"),
-                                          (Expr_const (Const_int 1))))
-                                        ])
-                                ))
+                             (Expr_call
+                                ((Expr_ident "factorial"),
+                                 (Some [(Expr_bin_oper (Bin_subtract,
+                                           (Expr_ident "n"),
+                                           (Expr_const (Const_int 1))))
+                                         ])))
                              )))))
            ))
          ])

--- a/Go/tests/test_ast.t
+++ b/Go/tests/test_ast.t
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
           (Stmt_return (Some (Expr_const (Const_int 1)))),
           (Some (Stmt_return
                    (Some (Expr_bin_oper (Bin_multiply, (Expr_ident "n"),
-                            (Expr_call ((Expr_ident "factorial"),
+                            (Expr_call (None, (Expr_ident "factorial"),
                                (Some [(Expr_bin_oper (Bin_subtract,
                                          (Expr_ident "n"),
                                          (Expr_const (Const_int 1))))

--- a/Go/tests/test_ast.t
+++ b/Go/tests/test_ast.t
@@ -2,20 +2,23 @@ Copyright 2024, Karim Shakirov, Alexei Dmitrievtsev
 SPDX-License-Identifier: MIT
 
   $ ../bin/astExample.exe
-  ("factorial", (Some [("n", (Some Type_int))]), (Some [Type_int]),
-   (Stmt_block
-      [(Stmt_if (None,
-          (Expr_bin_oper (Bin_equal, (Expr_ident "n"),
-             (Expr_const (Const_int 1)))),
-          (Stmt_return (Some (Expr_const (Const_int 1)))),
-          (Some (Stmt_return
-                   (Some (Expr_bin_oper (Bin_multiply, (Expr_ident "n"),
-                            (Expr_call (None, (Expr_ident "factorial"),
-                               (Some [(Expr_bin_oper (Bin_subtract,
-                                         (Expr_ident "n"),
-                                         (Expr_const (Const_int 1))))
-                                       ])
-                               ))
-                            )))))
-          ))
-        ]))
+  { func_name = "factorial"; args = (Some [("n", (Some Type_int))]);
+    return_types = (Some [(None, (Some Type_int))]);
+    body =
+    (Stmt_block
+       [(Stmt_if (None,
+           (Expr_bin_oper (Bin_equal, (Expr_ident "n"),
+              (Expr_const (Const_int 0)))),
+           (Stmt_return (Some (Expr_const (Const_int 1)))),
+           (Some (Stmt_return
+                    (Some (Expr_bin_oper (Bin_multiply, (Expr_ident "n"),
+                             (Expr_call (None, (Expr_ident "factorial"),
+                                (Some [(Expr_bin_oper (Bin_subtract,
+                                          (Expr_ident "n"),
+                                          (Expr_const (Const_int 1))))
+                                        ])
+                                ))
+                             )))))
+           ))
+         ])
+    }

--- a/Go/tests/test_ast.t
+++ b/Go/tests/test_ast.t
@@ -2,23 +2,25 @@ Copyright 2024, Karim Shakirov, Alexei Dmitrievtsev
 SPDX-License-Identifier: MIT
 
   $ ../bin/astExample.exe
-  { func_name = "factorial"; args = (Some [("n", (Some Type_int))]);
-    return_types = (Some [(None, (Some Type_int))]);
-    body =
-    (Stmt_block
-       [(Stmt_if (None,
-           (Expr_bin_oper (Bin_equal, (Expr_ident "n"),
-              (Expr_const (Const_int 0)))),
-           (Stmt_return (Some (Expr_const (Const_int 1)))),
-           (Some (Stmt_return
-                    (Some (Expr_bin_oper (Bin_multiply, (Expr_ident "n"),
-                             (Expr_call
-                                ((Expr_ident "factorial"),
-                                 (Some [(Expr_bin_oper (Bin_subtract,
-                                           (Expr_ident "n"),
-                                           (Expr_const (Const_int 1))))
-                                         ])))
-                             )))))
-           ))
-         ])
-    }
+  ("factorial",
+   { args = (Some [("n", (Some Type_int))]);
+     return_types = (Some [(None, (Some Type_int))]);
+     body =
+     (Some (Stmt_block
+              [(Stmt_if (None,
+                  (Expr_bin_oper (Bin_equal, (Expr_ident "n"),
+                     (Expr_const (Const_int 0)))),
+                  (Some (Stmt_return (Some (Expr_const (Const_int 1))))),
+                  (Some (Stmt_return
+                           (Some (Expr_bin_oper (Bin_multiply,
+                                    (Expr_ident "n"),
+                                    (Expr_call
+                                       ((Expr_ident "factorial"),
+                                        (Some [(Expr_bin_oper (Bin_subtract,
+                                                  (Expr_ident "n"),
+                                                  (Expr_const (Const_int 1))))
+                                                ])))
+                                    )))))
+                  ))
+                ]))
+     })


### PR DESCRIPTION
**Fixed:**

- Change operations types to operator types, move type constructors from them to ```Expr_bin_oper``` and ```Expr_un_oper```.
- Add ```Expr_array```.
- Move ```func_call``` to separate type to limit constructors of ```Stmt_go``` and ```Stmt_defer```.
- Change ```var_decl``` and ```func_decl``` types to records.
- Remove support for slices (arrays with floating capacity).
- Remove Stmt_empty.
- Create separate type for anon_func.